### PR TITLE
Improve Claude Code guidance and fix agent output parsing

### DIFF
--- a/codex-starter/skills/ask-agents/scripts/run-external-agent.mjs
+++ b/codex-starter/skills/ask-agents/scripts/run-external-agent.mjs
@@ -267,8 +267,12 @@ async function buildCommand(agent, parsed) {
     "text",
     "--output-format",
     "stream-json",
+    // No --include-partial-messages: this is a capture wrapper that only reads
+    // the final result. Partial-message envelopes (stream_event /
+    // content_block_delta) are not recognized by parseAgentOutput and bloat
+    // stdout, which can truncate the tail where the final result event lives —
+    // surfacing as a parse failure even though the report was produced.
     "--verbose",
-    "--include-partial-messages",
     "--permission-mode",
     "plan",
     "--no-session-persistence",

--- a/docs/starter-kit/index.md
+++ b/docs/starter-kit/index.md
@@ -33,9 +33,11 @@ works.
 Start with **Claude Code**. Use **Codex** after you understand the basic loop, or
 when you want a second app to inspect the same folder.
 
-In this guide, **Claude Code** means the installed app that can open a local
-folder, not Claude in a browser tab. **Codex** is optional; it is not part of
-the first 30 minutes.
+In this guide, **Claude Code** means the agent inside the Claude desktop app that
+can open a folder on your computer and act on its files — not a plain chat window.
+If your Claude window can't open or attach a local folder, you're in a plain chat,
+not Claude Code; switch to Claude Code before continuing. **Codex** is optional; it
+is not part of the first 30 minutes.
 
 <div class="starter-card" markdown>
 ### Claude Code: main workbench
@@ -103,6 +105,10 @@ Then run:
 /kit-hello
 ```
 
+You should see a short confirmation that the starter kit is installed and the
+commands are available. If instead you get "unknown command," the plugin didn't
+install — re-run the two `/plugin` lines above, then try again.
+
 You can stop here for the first session. Codex setup is optional after the first
 handoff.
 
@@ -169,6 +175,10 @@ When one small step is complete, run:
 
 Open `HANDOFF.md`. That file is the point of the exercise: it proves the next
 session can pick up where this one stopped.
+
+**Next time:** reopen the same folder and ask Claude Code to read `HANDOFF.md`
+first. That's how every future session starts — it's the whole reason you wrote
+the file.
 
 ## If Something Looks Scary
 

--- a/public-manifest.json
+++ b/public-manifest.json
@@ -46,9 +46,9 @@
       "sha256": "37578de36014e9163a2c104017589d93891aebd9d4064652094c7db8c89f69a4"
     },
     {
-      "bytes": 30894,
+      "bytes": 31239,
       "path": "codex-starter/skills/ask-agents/scripts/run-external-agent.mjs",
-      "sha256": "88f33603e9f2d073ac7286c142280fbcac7a0d672c956e053851d30e246214c9"
+      "sha256": "a58f89cc212be17d4a288397786e2f46530e02938760aff43fb14a419b3577a7"
     },
     {
       "bytes": 911,
@@ -81,9 +81,9 @@
       "sha256": "5e9f864cad9c6a6baa6a7f151d99ba9ab1a9eb6a107d5cb164ae5d4b747c3295"
     },
     {
-      "bytes": 10346,
+      "bytes": 10937,
       "path": "docs/starter-kit/index.md",
-      "sha256": "67e27eab9865193507b7b69ff495ba0080a74a73f209936201b0f704b247883c"
+      "sha256": "6e88e7f0f7afbddcba8674e0d02dd1dfb5dcc2d2f2dfab3b8ffb55dba2b6466f"
     },
     {
       "bytes": 15432,


### PR DESCRIPTION
## Summary
This PR improves documentation clarity for new users and fixes a critical issue with agent output parsing in the Codex starter kit.

## Key Changes

**Documentation improvements (docs/starter-kit/index.md):**
- Clarified the distinction between Claude Code (the agent in the desktop app) and plain chat windows, with guidance on how to identify and switch to Claude Code if needed
- Added confirmation message guidance after running the `/kit-hello` command to help users verify successful installation
- Added explicit instructions for future sessions on how to resume work by reading `HANDOFF.md` first

**Agent output parsing fix (codex-starter/skills/ask-agents/scripts/run-external-agent.mjs):**
- Removed the `--include-partial-messages` flag from the Claude API command
- Added detailed comments explaining why partial messages are excluded: they cause stdout bloat that can truncate the final result event, leading to parse failures even when the report was successfully produced
- The `parseAgentOutput` function only needs the final result event, not intermediate stream events

## Implementation Details
The agent output parsing fix addresses a subtle but critical issue where including partial message envelopes (stream_event and content_block_delta events) in stdout could cause the output buffer to grow large enough to truncate the tail of the stream, specifically the final result event that contains the actual report. This manifested as parse failures despite successful report generation. By excluding partial messages, we ensure only the essential final result event is captured.

https://claude.ai/code/session_011bDKoJRQVbxFEMNgBYxx9j